### PR TITLE
Use UCUM metadata schema for semmap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ scikit-learn
 scipy
 tabulate
 ucimlrepo
+ucumvert
 umap-learn

--- a/semmap_context.jsonld
+++ b/semmap_context.jsonld
@@ -9,6 +9,7 @@
     "sdmx-dimension": "http://purl.org/linked-data/sdmx/2009/dimension#",
     "schema": "https://schema.org/",
     "wd": "http://www.wikidata.org/entity/",
+    "dct": "http://purl.org/dc/terms/",
 
     "url": "csvw:url",
     "tableSchema": "csvw:tableSchema",
@@ -18,9 +19,11 @@
 
     "columnProperty": "dsv:columnProperty",
     "statisticalDataType": { "@id": "dsv:statisticalDataType", "@type": "@id" },
+    "valueType": { "@id": "dsv:valueType", "@type": "@id" },
     "hasCodeBook": { "@id": "dsv:hasCodeBook", "@type": "@id" },
 
     "notation": "skos:notation",
+    "prefLabel": "skos:prefLabel",
     "exactMatch": { "@id": "skos:exactMatch", "@type": "@id", "@container": "@set" },
     "closeMatch": { "@id": "skos:closeMatch", "@type": "@id", "@container": "@set" },
     "broadMatch": { "@id": "skos:broadMatch", "@type": "@id", "@container": "@set" },
@@ -30,6 +33,7 @@
 
     "hasQuantityKind": { "@id": "qudt:hasQuantityKind", "@type": "@id" },
     "hasUnit": { "@id": "qudt:hasUnit", "@type": "@id" },
-    "ucumCode": "qudt:ucumCode"
+    "ucumCode": "qudt:ucumCode",
+    "source": { "@id": "dct:source", "@type": "@id" }
   }
 }

--- a/semmap_schema.py
+++ b/semmap_schema.py
@@ -17,20 +17,24 @@ class SkosMappings:
 @dataclass
 class CodeConcept(SkosMappings):
     notation: Optional[str] = None
+    prefLabel: Optional[str] = None
 
 
 @dataclass
 class CodeBook:
     hasTopConcept: Optional[List[CodeConcept]] = None
+    source: Optional[str] = None
 
 
 # --- Column property (DSV + QUDT/UCUM) ---------------------------------------
 @dataclass
 class ColumnProperty(SkosMappings):
     statisticalDataType: Optional[str] = None          # e.g., "dsv:NominalDataType"
+    valueType: Optional[str] = None                    # e.g., "xsd:integer"
     hasQuantityKind: Optional[str] = None              # e.g., "quantitykind:Time"
     hasUnit: Optional[str] = None                      # e.g., "unit:YR"
     ucumCode: Optional[str] = None                     # e.g., "a"
+    source: Optional[str] = None                       # e.g., "https://loinc.org/..."
     hasCodeBook: Optional[CodeBook] = None
 
 

--- a/tests/fixtures/heart.metadata.json
+++ b/tests/fixtures/heart.metadata.json
@@ -1,4 +1,5 @@
 {
+  "@context": "https://w3id.org/semmap/context/v1",
   "dataset": {
     "@context": "https://w3id.org/semmap/context/v1",
     "@type": [
@@ -7,113 +8,95 @@
       "dcat:Dataset"
     ],
     "dct:title": "Heart dataset (example)",
-    "dct:description": "Example with variable/column JSON-LD and pint units.",
+    "dct:description": "Example with variable/column JSON-LD and UCUM units.",
     "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/"
   },
-  "disco:variable": [
-    {
-      "@context": "https://w3id.org/semmap/context/v1",
-      "@type": [
-        "disco:Variable",
-        "dsv:Column"
-      ],
-      "skos:notation": "cp",
-      "skos:prefLabel": "Chest pain type",
-      "disco:representation": {
-        "@type": [
-          "disco:Representation",
-          "skos:ConceptScheme"
-        ],
-        "skos:hasTopConcept": [
-          {
-            "@type": "skos:Concept",
-            "skos:notation": "1",
-            "skos:prefLabel": "Typical angina",
-            "skos:exactMatch": "http://snomed.info/id/429559004"
-          },
-          {
-            "@type": "skos:Concept",
-            "skos:notation": "2",
-            "skos:prefLabel": "Atypical angina",
-            "skos:exactMatch": "http://snomed.info/id/371807002"
-          },
-          {
-            "@type": "skos:Concept",
-            "skos:notation": "3",
-            "skos:prefLabel": "Non-cardiac chest pain",
-            "skos:exactMatch": "http://snomed.info/id/274668005"
-          },
-          {
-            "@type": "skos:Concept",
-            "skos:notation": "4",
-            "skos:prefLabel": "Asymptomatic",
-            "skos:exactMatch": "http://snomed.info/id/161971004"
+  "tableSchema": {
+    "columns": [
+      {
+        "name": "cp",
+        "titles": "Chest pain type",
+        "columnProperty": {
+          "statisticalDataType": "dsv:NominalDataType",
+          "source": "https://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_3202.html",
+          "hasCodeBook": {
+            "source": "https://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_3202.html",
+            "hasTopConcept": [
+              {
+                "notation": "1",
+                "prefLabel": "Typical angina",
+                "exactMatch": [
+                  "http://snomed.info/id/429559004"
+                ]
+              },
+              {
+                "notation": "2",
+                "prefLabel": "Atypical angina",
+                "exactMatch": [
+                  "http://snomed.info/id/371807002"
+                ]
+              },
+              {
+                "notation": "3",
+                "prefLabel": "Non-cardiac chest pain",
+                "exactMatch": [
+                  "http://snomed.info/id/274668005"
+                ]
+              },
+              {
+                "notation": "4",
+                "prefLabel": "Asymptomatic",
+                "exactMatch": [
+                  "http://snomed.info/id/161971004"
+                ]
+              }
+            ]
           }
-        ],
-        "dct:source": "https://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_3202.html"
+        }
       },
-      "dct:source": "https://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_3202.html"
-    },
-    {
-      "@context": "https://w3id.org/semmap/context/v1",
-      "@type": [
-        "disco:Variable",
-        "dsv:Column"
-      ],
-      "skos:notation": "fbs",
-      "skos:prefLabel": "Fasting blood sugar >120 mg/dL (indicator)",
-      "disco:representation": {
-        "@type": [
-          "disco:Representation",
-          "skos:ConceptScheme"
-        ],
-        "skos:hasTopConcept": [
-          {
-            "@type": "skos:Concept",
-            "skos:notation": "0",
-            "skos:prefLabel": "≤120 mg/dL"
-          },
-          {
-            "@type": "skos:Concept",
-            "skos:notation": "1",
-            "skos:prefLabel": ">120 mg/dL"
+      {
+        "name": "fbs",
+        "titles": "Fasting blood sugar >120 mg/dL (indicator)",
+        "columnProperty": {
+          "statisticalDataType": "dsv:NominalDataType",
+          "source": "https://loinc.org/2345-7",
+          "hasCodeBook": {
+            "source": "https://loinc.org/2345-7",
+            "hasTopConcept": [
+              {
+                "notation": "0",
+                "prefLabel": "\u2264120 mg/dL"
+              },
+              {
+                "notation": "1",
+                "prefLabel": ">120 mg/dL"
+              }
+            ]
           }
-        ],
-        "dct:source": "https://loinc.org/2345-7"
+        }
       },
-      "dct:source": "https://loinc.org/2345-7"
-    },
-    {
-      "@context": "https://w3id.org/semmap/context/v1",
-      "@type": [
-        "disco:Variable",
-        "dsv:Column"
-      ],
-      "skos:notation": "trestbps",
-      "skos:prefLabel": "Resting systolic blood pressure",
-      "disco:representation": {
-        "@type": "disco:Representation",
-        "dsv:valueType": "xsd:integer",
-        "qudt:hasUnit": "unit:MilliM_HG",
-        "semmap:pintUnit": "mmHg"
+      {
+        "name": "trestbps",
+        "titles": "Resting systolic blood pressure",
+        "columnProperty": {
+          "statisticalDataType": "dsv:QuantitativeDataType",
+          "valueType": "xsd:integer",
+          "hasUnit": "unit:MilliM_HG",
+          "ucumCode": "mm[Hg]",
+          "source": "https://loinc.org/8480-6"
+        }
       },
-      "dct:source": "https://loinc.org/8480-6"
-    },
-    {
-      "@context": "https://w3id.org/semmap/context/v1",
-      "@type": [
-        "disco:Variable",
-        "dsv:Column"
-      ],
-      "skos:notation": "chol",
-      "skos:prefLabel": "Total cholesterol",
-      "disco:representation": {
-        "@type": "disco:Representation",
-        "dsv:valueType": "xsd:integer",
-        "qudt:hasUnit": "unit:MilliGM-PER-DeciL",
-        "semmap:pintUnit": "mg/dL"
-      },
-      "dct:source": "https://loinc.org/2093-3"
-    }
-  ]
+      {
+        "name": "chol",
+        "titles": "Total cholesterol",
+        "columnProperty": {
+          "statisticalDataType": "dsv:QuantitativeDataType",
+          "valueType": "xsd:integer",
+          "hasUnit": "unit:MilliGM-PER-DeciL",
+          "ucumCode": "mg/dL",
+          "source": "https://loinc.org/2093-3"
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- integrate semmap_schema dataclasses into the semmap accessor to emit and parse tableSchema metadata, including UCUM-aware unit handling and legacy fallbacks
- extend the JSON-LD context and schema dataclasses with prefLabel, valueType, and source fields required for the new schema
- add the ucumvert dependency and refresh the heart metadata fixture to the new tableSchema format

## Testing
- PYTHONPATH=. pytest tests/test_semmap.py

------
https://chatgpt.com/codex/tasks/task_e_68cac43313a08332a7ec9f491be24111