### PR TITLE
Refactor missingness helpers into shared module

### DIFF
--- a/semsynth/backends/missingness.py
+++ b/semsynth/backends/missingness.py
@@ -1,0 +1,7 @@
+"""Backward-compatible re-export for missingness utilities."""
+
+from __future__ import annotations
+
+from ..missingness import DataFrameMissingnessModel, MissingnessWrappedGenerator
+
+__all__ = ["DataFrameMissingnessModel", "MissingnessWrappedGenerator"]

--- a/semsynth/pipeline.py
+++ b/semsynth/pipeline.py
@@ -44,6 +44,8 @@ class PipelineConfig:
     compute_privacy: bool = False
     compute_downstream: bool = False
     overwrite_umap: bool = False
+    enable_missingness_wrapping: bool = False
+    missingness_random_state: Optional[int] = None
 
 
 def _load_backend_module(name: str) -> BackendModule:
@@ -179,6 +181,7 @@ class PreprocessingResult:
     color_series: Optional["pd.Series"]
     umap_png_real: Optional[Path]
     umap_artifacts: Optional[UmapArtifacts]
+    missingness_model: Optional["DataFrameMissingnessModel"]
 
 
 class DatasetPreprocessor:
@@ -294,7 +297,25 @@ class DatasetPreprocessor:
 
         df_fit_sample = df_no_na
         if cfg.fit_on_sample and cfg.fit_on_sample < len(df_fit_sample):
-            df_fit_sample = df_no_na.sample(cfg.fit_on_sample, random_state=cfg.random_state)
+            df_fit_sample = df_no_na.sample(
+                cfg.fit_on_sample, random_state=cfg.random_state
+            )
+
+        missingness_model: Optional["DataFrameMissingnessModel"] = None
+        if cfg.enable_missingness_wrapping:
+            miss_state = cfg.missingness_random_state
+            if miss_state is None:
+                miss_state = cfg.random_state
+            try:
+                from . import missingness as missingness_module
+            except ImportError:
+                logging.warning(
+                    "Missingness wrapping requested but dependencies are unavailable"
+                )
+            else:
+                missingness_model = missingness_module.fit_missingness_model(
+                    df_processed, random_state=miss_state
+                )
 
         return PreprocessingResult(
             df_processed=df_processed,
@@ -307,6 +328,7 @@ class DatasetPreprocessor:
             color_series=color_series2,
             umap_png_real=umap_png_real,
             umap_artifacts=umap_artifacts,
+            missingness_model=missingness_model,
         )
 
 
@@ -463,7 +485,29 @@ class BackendExecutor:
                 continue
 
             run_dir_path = Path(run_dir)
-            synth_df = pd.read_csv(run_dir_path / "synthetic.csv").convert_dtypes()
+            synth_path = run_dir_path / "synthetic.csv"
+            synth_df = pd.read_csv(synth_path).convert_dtypes()
+
+            missingness_applied = False
+            if preprocessed.missingness_model is not None:
+                try:
+                    from . import missingness as missingness_module
+                except ImportError:
+                    logging.warning(
+                        "Missingness wrapping requested but dependencies are unavailable"
+                    )
+                else:
+                    synth_df, missingness_applied = (
+                        missingness_module.apply_missingness_to_outputs(
+                            run_dir=run_dir_path,
+                            synth_df=synth_df,
+                            missingness_model=preprocessed.missingness_model,
+                            real_df=preprocessed.df_no_na,
+                            disc_cols=preprocessed.disc_cols,
+                            cont_cols=preprocessed.cont_cols,
+                            backend_name=backend_name,
+                        )
+                    )
 
             compute_privacy_flag = _resolve_flag(
                 self._cfg.compute_privacy,
@@ -586,6 +630,15 @@ class ReportWriter:
             variable_descriptions: Optional variable description mapping.
         """
 
+        try:
+            from . import missingness as missingness_module
+        except ImportError:
+            missingness_summary = None
+        else:
+            missingness_summary = missingness_module.summarize_missingness_model(
+                preprocessed.missingness_model
+            )
+
         self._reporting.write_report_md(
             outdir=str(outdir),
             dataset_name=dataset_spec.name,
@@ -601,8 +654,8 @@ class ReportWriter:
             variable_descriptions=variable_descriptions or None,
             semmap_jsonld=preprocessed.semmap_export,
             model_runs=model_runs,
+            missingness_summary=missingness_summary,
         )
-
 
 def process_dataset(
     dataset_spec: "DatasetSpec",

--- a/templates/report.md.j2
+++ b/templates/report.md.j2
@@ -7,11 +7,20 @@
 {% endif %}- Rows: {{ num_rows }}
 - Columns: {{ num_cols }}
 - Discrete: {{ num_disc }}  |  Continuous: {{ num_cont }}
+{% if missingness_summary %}- Missingness model: enabled{% if missingness_summary.random_state is not none %} (random state {{ missingness_summary.random_state }}){% endif %} — modeled columns {{ missingness_summary.nonzero_count }} of {{ missingness_summary.total_columns }}{% endif %}
 
 ## Variables and summary
 
 {{ variable_table }}
 
+{% if missingness_summary %}## Missingness model
+
+- Columns with learned missingness: {{ missingness_summary.nonzero_count }} of {{ missingness_summary.total_columns }}
+{% if missingness_summary.zero_count %}- Columns without missingness: {{ missingness_summary.zero_count }}{% endif %}
+{% if missingness_table %}{{ missingness_table }}{% else %}No columns required missingness injection.
+{% endif %}
+
+{% endif %}
 {% if fidelity_table %}## Fidelity summary
 
 {{ fidelity_table }}
@@ -27,7 +36,7 @@
 
 - Seed: {{ model.seed }}, rows: {{ model.rows }}
 {% if model.params_json %}- Params: `{{ model.params_json }}`
-{% endif %}{% for link in model.links %}- [{{ link.label }}]({{ link.href }})
+{% endif %}{% if model.missingness %}- Missingness: {% if model.missingness.wrapped %}wrapped{% else %}{{ model.missingness }}{% endif %}{% if model.missingness.random_state is not none %} (random state {{ model.missingness.random_state }}){% endif %}{% if model.missingness.source %} via {{ model.missingness.source }}{% endif %}{% endif %}{% for link in model.links %}- [{{ link.label }}]({{ link.href }})
 {% endfor %}
 
 </td><td>

--- a/tests/test_pipeline_components.py
+++ b/tests/test_pipeline_components.py
@@ -100,6 +100,7 @@ def _create_preprocessing_result(df: pd.DataFrame, tmp_path) -> PreprocessingRes
         color_series=None,
         umap_png_real=None,
         umap_artifacts=UmapArtifacts(transformer=None, real_png=tmp_path / "umap.png", limits=None),
+        missingness_model=None,
     )
 
 
@@ -294,6 +295,7 @@ def test_report_writer_generates_outputs(tmp_path):
             real_png=tmp_path / "umap_real.png",
             limits={"x": 1.0},
         ),
+        missingness_model=None,
     )
 
     umap_stub = _StubUmapModule()

--- a/tests/test_pipeline_missingness.py
+++ b/tests/test_pipeline_missingness.py
@@ -1,0 +1,284 @@
+"""Tests covering optional missingness wrapping in the pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from semsynth.models import ModelConfigBundle, ModelSpec
+from semsynth.pipeline import (
+    BackendExecutor,
+    DatasetPreprocessor,
+    MetricWriter,
+    PipelineConfig,
+    ReportWriter,
+)
+from semsynth.specs import DatasetSpec
+
+
+class _DummyUtils:
+    """Minimal stand-in for :mod:`semsynth.utils` utilities."""
+
+    @staticmethod
+    def ensure_dir(path: str) -> None:
+        Path(path).mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def infer_types(df: pd.DataFrame) -> tuple[list[str], list[str]]:
+        cont = [c for c in df.select_dtypes(include=["number"]).columns]
+        disc = [c for c in df.columns if c not in cont]
+        return disc, cont
+
+    @staticmethod
+    def coerce_discrete_to_category(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+        return df
+
+    @staticmethod
+    def rename_categorical_categories_to_str(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+        return df
+
+    @staticmethod
+    def coerce_continuous_to_float(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+        return df
+
+    @staticmethod
+    def seed_all(seed: int) -> np.random.Generator:
+        return np.random.default_rng(seed)
+
+
+class _NoopMetricWriter(MetricWriter):
+    """Metric writer that records calls without touching disk."""
+
+    def __init__(self) -> None:
+        super().__init__(privacy_summarizer=None, downstream_compare=None)
+        self.privacy_calls: list[dict] = []
+        self.downstream_calls: list[dict] = []
+
+    def write_privacy(self, *args, **kwargs):  # type: ignore[override]
+        self.privacy_calls.append({"args": args, "kwargs": kwargs})
+        return {}
+
+    def write_downstream(self, *args, **kwargs):  # type: ignore[override]
+        self.downstream_calls.append({"args": args, "kwargs": kwargs})
+        return {}
+
+
+@pytest.fixture()
+def dummy_utils() -> _DummyUtils:
+    """Provide dummy utility helpers for preprocessing."""
+
+    return _DummyUtils()
+
+
+def _make_preprocessor(dummy_utils: _DummyUtils) -> DatasetPreprocessor:
+    """Build a :class:`DatasetPreprocessor` bound to dummy helpers."""
+
+    return DatasetPreprocessor(
+        utils_module=dummy_utils,
+        load_mapping=lambda *_: None,
+        resolve_mapping=lambda *_: None,
+    )
+
+
+def test_preprocess_builds_missingness_model(
+    tmp_path: Path, dummy_utils: _DummyUtils
+) -> None:
+    """Verify preprocessing optionally fits the missingness model."""
+
+    df = pd.DataFrame(
+        {
+            "num": [0.0, 1.0, np.nan, 2.0, np.nan, 1.5],
+            "cat": ["a", "b", "a", "b", "a", "b"],
+        }
+    )
+    spec = DatasetSpec(provider="demo", name="demo")
+    cfg = PipelineConfig(
+        enable_missingness_wrapping=True,
+        missingness_random_state=123,
+        generate_umap=False,
+    )
+    rng = dummy_utils.seed_all(42)
+
+    preprocessor = _make_preprocessor(dummy_utils)
+    result = preprocessor.preprocess(
+        spec,
+        df,
+        color_series=None,
+        outdir=tmp_path,
+        cfg=cfg,
+        rng=rng,
+        generate_umap=False,
+        umap_utils=None,
+    )
+
+    assert result.missingness_model is not None
+    assert result.missingness_model.random_state == 123
+    assert set(result.missingness_model.models_) == {"num", "cat"}
+
+
+def test_backend_executor_applies_missingness(
+    tmp_path: Path, dummy_utils: _DummyUtils
+) -> None:
+    """Ensure backend outputs are wrapped with learned missingness."""
+
+    df = pd.DataFrame(
+        {
+            "num": [0.0, np.nan, 1.0, np.nan, 0.5, 1.5, np.nan, 2.5],
+            "cat": ["a", "b", "a", "b", "a", "b", "a", "b"],
+        }
+    )
+    spec = DatasetSpec(provider="demo", name="demo", target=None)
+    cfg = PipelineConfig(
+        enable_missingness_wrapping=True,
+        missingness_random_state=5,
+        compute_privacy=False,
+        compute_downstream=False,
+        generate_umap=False,
+    )
+    rng = dummy_utils.seed_all(7)
+
+    preprocessor = _make_preprocessor(dummy_utils)
+    preprocessed = preprocessor.preprocess(
+        spec,
+        df,
+        color_series=None,
+        outdir=tmp_path,
+        cfg=cfg,
+        rng=rng,
+        generate_umap=False,
+        umap_utils=None,
+    )
+
+    class _StubBackend:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def run_experiment(
+            self,
+            *,
+            df: pd.DataFrame,
+            provider,
+            dataset_name,
+            provider_id,
+            outdir: str,
+            label: str,
+            model_info,
+            rows: int,
+            seed: int,
+            test_size: float,
+            semmap_export,
+        ) -> Path:
+            run_dir = Path(outdir) / "models" / label
+            run_dir.mkdir(parents=True, exist_ok=True)
+            synth = pd.DataFrame(
+                {
+                    "num": np.linspace(0.0, 3.0, num=20, endpoint=False),
+                    "cat": ["a", "b"] * 10,
+                }
+            )
+            synth.to_csv(run_dir / "synthetic.csv", index=False)
+            (run_dir / "manifest.json").write_text(
+                json.dumps({"backend": "stub", "name": label}),
+                encoding="utf-8",
+            )
+            (run_dir / "metrics.json").write_text(
+                json.dumps({"backend": "stub"}),
+                encoding="utf-8",
+            )
+            self.calls.append({"label": label, "rows": rows, "seed": seed})
+            return run_dir
+
+    backend = _StubBackend()
+    bundle = ModelConfigBundle(
+        specs=[ModelSpec(name="stub", backend="stub", model={}, rows=None, seed=None)]
+    )
+    metric_writer = _NoopMetricWriter()
+    executor = BackendExecutor(
+        cfg,
+        load_backend=lambda name: backend,
+        metric_writer=metric_writer,
+    )
+
+    outdir = tmp_path / "dataset"
+    outdir.mkdir(parents=True, exist_ok=True)
+    executor.run_models(spec, bundle, preprocessed, outdir)
+
+    run_dir = outdir / "models" / "stub"
+    wrapped_df = pd.read_csv(run_dir / "synthetic.csv")
+    pristine_df = pd.read_csv(run_dir / "synthetic.nomissing.csv")
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    metrics = json.loads((run_dir / "metrics.json").read_text(encoding="utf-8"))
+
+    assert wrapped_df.isna().any().any(), "wrapped data should contain missing values"
+    assert not pristine_df.isna().any().any(), "original synthetic data should be preserved"
+    assert manifest.get("missingness", {}).get("wrapped") is True
+    assert manifest.get("missingness", {}).get("source") == "pipeline"
+    assert metrics.get("missingness_wrapped") is True
+    assert (run_dir / "per_variable_metrics.csv").exists()
+
+    assert not metric_writer.privacy_calls
+    assert not metric_writer.downstream_calls
+
+
+def test_report_writer_includes_missingness_summary(
+    tmp_path: Path, dummy_utils: _DummyUtils
+) -> None:
+    """Report writer should forward missingness metadata to reporting."""
+
+    df = pd.DataFrame(
+        {
+            "num": [0.0, np.nan, 1.0, 2.0],
+            "cat": ["a", "b", "a", "b"],
+        }
+    )
+    spec = DatasetSpec(provider="demo", name="demo")
+    cfg = PipelineConfig(
+        enable_missingness_wrapping=True,
+        missingness_random_state=99,
+        generate_umap=False,
+    )
+    rng = dummy_utils.seed_all(11)
+
+    preprocessor = _make_preprocessor(dummy_utils)
+    preprocessed = preprocessor.preprocess(
+        spec,
+        df,
+        color_series=None,
+        outdir=tmp_path,
+        cfg=cfg,
+        rng=rng,
+        generate_umap=False,
+        umap_utils=None,
+    )
+
+    class ReportingStub:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def write_report_md(self, **kwargs: Any) -> None:
+            self.calls.append(kwargs)
+
+    reporting_stub = ReportingStub()
+    reporter = ReportWriter(reporting_stub, umap_utils=None)
+
+    reporter.write_report(
+        outdir=tmp_path,
+        dataset_spec=spec,
+        preprocessed=preprocessed,
+        model_runs=[],
+        inferred_types=preprocessed.inferred_types,
+        variable_descriptions=None,
+    )
+
+    assert reporting_stub.calls, "reporting stub should receive a call"
+    summary = reporting_stub.calls[0].get("missingness_summary")
+    assert summary is not None
+    assert summary["random_state"] == 99
+    assert summary["total_columns"] == 2
+    assert summary["nonzero_count"] >= 1
+    assert summary["rows"], "missingness summary should include per-column rates"


### PR DESCRIPTION
## Summary
- delegate fitting, application, and summarization of missingness models to `semsynth/missingness.py`
- simplify pipeline preprocessing, backend execution, and reporting to consume the shared helpers

## Testing
- pytest tests/test_reporting.py tests/test_pipeline_missingness.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918405b0a6c8332a278e6c0fecc2f37)