### PR TITLE
Handle optional metadata in shared column loader

### DIFF
--- a/map_columns/shared.py
+++ b/map_columns/shared.py
@@ -1,0 +1,123 @@
+"""Shared helpers for parsing dataset column metadata."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DatasetMetadata:
+    """Dataset-level metadata extracted from DCAT/DSV JSON."""
+
+    title: Optional[str] = None
+    description: Optional[str] = None
+    table_of_contents: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Optional[str]]:
+        """Return the metadata as a dictionary."""
+        return {
+            "title": self.title,
+            "description": self.description,
+            "table_of_contents": self.table_of_contents,
+        }
+
+
+@dataclass(frozen=True)
+class ColumnInfo:
+    """Flattened representation of a ``dsv:column`` entry."""
+
+    column_id: Optional[str]
+    name: Optional[str]
+    description: Optional[str] = None
+    about: Optional[str] = None
+    unit: Optional[str] = None
+    role: Optional[str] = None
+    statistical_data_type: Optional[str] = None
+    summary_statistics: Optional[Dict[str, Any]] = None
+
+
+def _ensure_list(value: Any) -> Iterable[Any]:
+    """Return ``value`` as an iterable list."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _coerce_optional_str(value: Any) -> Optional[str]:
+    """Convert ``value`` to a trimmed string when possible."""
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float)):
+        text = str(value).strip()
+        return text or None
+    return None
+
+
+def load_columns(path: Path) -> Tuple[List[ColumnInfo], DatasetMetadata]:
+    """Load dataset metadata and column definitions from JSON.
+
+    Args:
+        path: Location of the DCAT/DSV JSON/JSON-LD file.
+
+    Returns:
+        A tuple of ``(columns, dataset_metadata)`` where ``columns`` is a list
+        of :class:`ColumnInfo` and ``dataset_metadata`` describes the dataset.
+    """
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    metadata = DatasetMetadata(
+        title=_coerce_optional_str(data.get("dcterms:title")),
+        description=_coerce_optional_str(data.get("dcterms:description")),
+        table_of_contents=_coerce_optional_str(data.get("dcterms:tableOfContents")),
+    )
+
+    schema = data.get("dsv:datasetSchema") or {}
+    raw_columns = _ensure_list(schema.get("dsv:column") or [])
+
+    columns: List[ColumnInfo] = []
+    for entry in raw_columns:
+        if not isinstance(entry, dict):
+            continue
+
+        name = (
+            _coerce_optional_str(entry.get("schema:name"))
+            or _coerce_optional_str(entry.get("dcterms:title"))
+            or _coerce_optional_str(entry.get("schema:identifier"))
+        )
+        if not name:
+            continue
+
+        column_id = _coerce_optional_str(entry.get("schema:identifier")) or name
+
+        summary_stats_raw = entry.get("dsv:summaryStatistics")
+        summary_stats: Optional[Dict[str, Any]] = None
+        statistical_data_type: Optional[str] = None
+        if isinstance(summary_stats_raw, dict):
+            summary_stats = dict(summary_stats_raw)
+            statistical_data_type = _coerce_optional_str(
+                summary_stats_raw.get("dsv:statisticalDataType")
+            )
+
+        columns.append(
+            ColumnInfo(
+                column_id=column_id,
+                name=name,
+                description=_coerce_optional_str(entry.get("dcterms:description")),
+                about=_coerce_optional_str(entry.get("schema:about")),
+                unit=_coerce_optional_str(entry.get("schema:unitText")),
+                role=_coerce_optional_str(entry.get("prov:hadRole")),
+                statistical_data_type=statistical_data_type,
+                summary_statistics=summary_stats,
+            )
+        )
+
+    logger.info("Loaded %d columns from %s", len(columns), path)
+    return columns, metadata

--- a/tests/test_map_columns_shared.py
+++ b/tests/test_map_columns_shared.py
@@ -1,0 +1,112 @@
+"""Tests for map_columns.shared helper utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from map_columns.shared import ColumnInfo, DatasetMetadata, load_columns
+
+
+@pytest.fixture()
+def dataset_json(tmp_path: Path) -> Path:
+    """Create a dataset JSON file with multiple column shapes."""
+    data = {
+        "dcterms:title": "Test dataset",
+        "dcterms:description": "Example description",
+        "dcterms:tableOfContents": "Column A: details",
+        "dsv:datasetSchema": {
+            "dsv:column": [
+                {
+                    "schema:name": "col_a",
+                    "dcterms:description": "First column",
+                    "schema:about": "About A",
+                    "schema:unitText": "kg",
+                    "prov:hadRole": "measure",
+                    "dsv:summaryStatistics": {
+                        "dsv:statisticalDataType": "quantitative",
+                        "count": 10,
+                    },
+                },
+                {
+                    "dcterms:title": "Column B",
+                    "schema:identifier": "col_b",
+                    "dcterms:description": "Second column",
+                },
+            ]
+        },
+    }
+    path = tmp_path / "dataset.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_load_columns_returns_structured_data(dataset_json: Path) -> None:
+    """load_columns should parse dataset and column metadata into dataclasses."""
+    columns, meta = load_columns(dataset_json)
+
+    assert isinstance(meta, DatasetMetadata)
+    assert meta.as_dict() == {
+        "title": "Test dataset",
+        "description": "Example description",
+        "table_of_contents": "Column A: details",
+    }
+
+    assert len(columns) == 2
+    first, second = columns
+    assert isinstance(first, ColumnInfo)
+    assert first.column_id == "col_a"
+    assert first.name == "col_a"
+    assert first.description == "First column"
+    assert first.about == "About A"
+    assert first.unit == "kg"
+    assert first.role == "measure"
+    assert first.statistical_data_type == "quantitative"
+    assert first.summary_statistics is not None
+    assert first.summary_statistics["count"] == 10
+
+    assert second.column_id == "col_b"
+    assert second.name == "Column B"
+    assert second.description == "Second column"
+    assert second.summary_statistics is None
+
+
+def test_load_columns_handles_single_column_object(tmp_path: Path) -> None:
+    """A solitary dict for dsv:column should be coerced into a list."""
+    data = {
+        "dsv:datasetSchema": {
+            "dsv:column": {
+                "schema:identifier": "single",
+                "dcterms:description": "Only column",
+            }
+        }
+    }
+    path = tmp_path / "single.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    columns, meta = load_columns(path)
+
+    assert meta.title is None
+    assert len(columns) == 1
+    assert columns[0].name == "single"
+    assert columns[0].description == "Only column"
+
+
+def test_load_columns_ignores_invalid_entries(tmp_path: Path) -> None:
+    """Non-dict or unnamed entries should be skipped."""
+    data = {
+        "dsv:datasetSchema": {
+            "dsv:column": [
+                "bad",
+                {"not_useful": True},
+                {"schema:name": "valid", "dcterms:description": "works"},
+            ]
+        }
+    }
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    columns, _ = load_columns(path)
+    assert [col.name for col in columns] == ["valid"]


### PR DESCRIPTION
## Summary
- make DatasetMetadata and ColumnInfo fields optional and coerce missing values when loading column definitions
- update the keyword and LLM mapping scripts to tolerate missing column metadata
- refresh the shared loader tests to assert Optional outputs for absent fields

## Testing
- pytest tests/test_map_columns_shared.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691844e6162c8332a2f4378d8e7d0dad)